### PR TITLE
Use filters to instead of includes and excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ provider "unarchive" {
 
 ## Usage
 
-Please refer to [Docs](https://registry.terraform.io/providers/hashicorp/archive/latest/docs) for more details.
+Please refer to [Docs](https://registry.terraform.io/providers/babybabycloud/unarchive/latest/docs) for more details.

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -51,13 +51,21 @@ output "targz_output" {
 
 ### Optional
 
-- `excludes` (List of String) inclules specifies which file should not be extracted. It uses regular express to find the files. It is a list
+- `filters` (Attributes List) filters specifies what to be included and excluded (see [below for nested schema](#nestedatt--filters))
 - `flat` (Boolean) flat specifies if the directory should be ignored.
-- `includes` (List of String) inclules specifies which file should be extracted. It uses regular express to find the files. It is a list
 - `output` (String) output specifies where the extracted files to be put.
 
 ### Read-Only
 
 - `file_names` (List of String) file_names indicates whar files have been extracted.
+
+<a id="nestedatt--filters"></a>
+### Nested Schema for `filters`
+
+Optional:
+
+- `excludes` (List of String) inclules specifies which file should not be extracted. It uses regular express to find the files. It is a list
+- `includes` (List of String) inclules specifies which file should be extracted. It uses regular express to find the files. It is a list
+
 
 

--- a/examples/targz.tf
+++ b/examples/targz.tf
@@ -4,8 +4,12 @@ data "unarchive_file" "targz" {
   type = ".tar.gz"
   filters = [
     {
-      "includes": ["operations/lists"],
-      "excludes": ["P"]
+      "includes": ["Objects"],
+      "excludes": ["\\.h$"]
+    },
+    {
+      "includes": ["Lib"],
+      "excludes": ["\\.py$"],
     }
   ]
 }

--- a/examples/targz.tf
+++ b/examples/targz.tf
@@ -2,8 +2,12 @@ data "unarchive_file" "targz" {
   file_name = "Python-3.11.3.tgz"
   output = "targz"
   type = ".tar.gz"
-  includes = ["Object"]
-  excludes = ["\\.c"]
+  filters = [
+    {
+      "includes": ["operations/lists"],
+      "excludes": ["P"]
+    }
+  ]
 }
 
 output "targz_output" {

--- a/internal/unarchive/common/patterns.go
+++ b/internal/unarchive/common/patterns.go
@@ -9,24 +9,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-type patterns []string
+type Patterns []string
 
 // ToPatterns converts string elements in types.List to []string
-func ToPatterns(list types.List) patterns {
-	var p patterns
+func ToPatterns(list types.List) Patterns {
+	var p Patterns
 	if !list.IsNull() {
-		patternsInType := make([]types.String, len(list.Elements()))
-		p = make(patterns, len(list.Elements()))
-		list.ElementsAs(context.TODO(), &patternsInType, false)
-		for index, value := range patternsInType {
+		PatternsInType := make([]types.String, len(list.Elements()))
+		p = make(Patterns, len(list.Elements()))
+		list.ElementsAs(context.TODO(), &PatternsInType, false)
+		for index, value := range PatternsInType {
 			p[index] = value.ValueString()
 		}
 	}
 	return p
 }
 
-// DoesNameMatch checkes if the name matches any value in patterns
-func (p patterns) DoesNameMatch(name string) bool {
+// DoesNameMatch checkes if the name matches any value in Patterns
+func (p Patterns) doesNameMatch(name string) bool {
 	for _, value := range p {
 		matched, err := regexp.MatchString(value, name)
 
@@ -38,4 +38,20 @@ func (p patterns) DoesNameMatch(name string) bool {
 		}
 	}
 	return false
+}
+
+// Include checks if the name is included in the patters
+func (p Patterns) Include(name string) bool {
+	if len(p) == 0 {
+		return true
+	}
+	return p.doesNameMatch(name)
+}
+
+// Exclude checks if the name is not included in the patters
+func (p Patterns) Exclude(name string) bool {
+	if len(p) == 0 {
+		return false
+	}
+	return p.doesNameMatch(name)
 }

--- a/internal/unarchive/common/patterns_test.go
+++ b/internal/unarchive/common/patterns_test.go
@@ -21,28 +21,56 @@ func TestToPattern(t *testing.T) {
 	}
 	list, _ := types.ListValueFrom(context.TODO(), types.StringType, elements)
 	p := ToPatterns(list)
-	assert.Equal(t, patterns(elements), p)
+	assert.Equal(t, Patterns(elements), p)
 
 }
 
 func TestDoesNameMatchTrue(t *testing.T) {
-	elements := patterns{
+	elements := Patterns{
 		"src",
 		"Makefile",
 		`^main\.py$`,
 	}
 
-	result := elements.DoesNameMatch("go/src")
+	result := elements.doesNameMatch("go/src")
 	assert.True(t, result)
 }
 
 func TestDoesNameMatchFalse(t *testing.T) {
-	elements := patterns{
+	elements := Patterns{
 		"src",
 		"Makefile",
 		`^main\.py$`,
 	}
 
-	result := elements.DoesNameMatch("go/hello.py")
+	result := elements.doesNameMatch("go/hello.py")
 	assert.False(t, result)
+}
+
+func TestIncludeZeroLength(t *testing.T) {
+	p := make(Patterns, 0)
+	assert.True(t, p.Include("any"))
+}
+
+func TestIncludeMatch(t *testing.T) {
+	p := Patterns{
+		"http",
+		"net",
+	}
+
+	assert.True(t, p.Include("net.py"))
+}
+
+func TestExcludeZeroLength(t *testing.T) {
+	p := make(Patterns, 0)
+	assert.False(t, p.Exclude("any"))
+}
+
+func TestExcludeMatch(t *testing.T) {
+	p := Patterns{
+		"http",
+		"net",
+	}
+
+	assert.True(t, p.Exclude("http"))
 }

--- a/internal/unarchive/extract/config.go
+++ b/internal/unarchive/extract/config.go
@@ -63,7 +63,7 @@ func (c *Config) isSkip(name string) bool {
 			return false
 		}
 	}
-	return true
+	return len(c.Filters) != 0
 }
 
 func (c *Config) correctFileName(filename string) string {

--- a/internal/unarchive/extract/config.go
+++ b/internal/unarchive/extract/config.go
@@ -3,25 +3,67 @@ package extract
 import (
 	"context"
 	"path/filepath"
+
+	"github.com/babybabycloud/terraform-provider-unarchive/internal/unarchive/common"
+	"github.com/babybabycloud/terraform-provider-unarchive/internal/unarchive/model"
 )
 
-// TestFunc is a function with a string parameter to check includes and excludes
-type TestFunc func(string) bool
+// ConfigFilter stores the expressions of include and exclude
+type ConfigFilter struct {
+	Includes common.Patterns
+	Excludes common.Patterns
+}
+
+// FormFilterModel constructs an instance of ConfigFilter using model.FilterModel
+func FromFilterModel(f model.FilterModel) ConfigFilter {
+	var filter ConfigFilter
+	if !f.Includes.IsNull() {
+		filter.Includes = common.ToPatterns(f.Includes)
+	}
+
+	if !f.Excludes.IsNull() {
+		filter.Excludes = common.ToPatterns(f.Excludes)
+	}
+	return filter
+}
+
+func (f ConfigFilter) isSkip(name string) bool {
+	return !f.Includes.Include(name) || f.Excludes.Exclude(name)
+}
 
 // Config is an internal form of unarchive data source model
 type Config struct {
 	Ctx     context.Context
 	Name    string
-	Include TestFunc
-	Exclude TestFunc
+	Filters []ConfigFilter
 	Outdir  string
 	IsFlat  bool
 	Type    string
 }
 
+// FromUnarchiveDataSourceModel creates a pointer refering to an instanc of Config
+func FromUnarchiveDataSourceModel(m model.UnarchiveDataSourceModel) *Config {
+	conf := new(Config)
+	conf.Name = m.FileName.ValueString()
+	conf.Outdir = m.DecideOutputDir()
+	conf.IsFlat = m.IsFlat()
+	conf.Type = m.Type.ValueString()
+
+	filters := make([]ConfigFilter, len(m.Filters))
+	for index, filter := range m.Filters {
+		filters[index] = FromFilterModel(filter)
+	}
+	conf.Filters = filters
+	return conf
+}
+
 func (c *Config) isSkip(name string) bool {
-	var isSkip bool
-	return isSkip || !c.Include(name) || c.Exclude(name)
+	for _, filter := range c.Filters {
+		if !filter.isSkip(name) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Config) correctFileName(filename string) string {

--- a/internal/unarchive/extract/extract_test.go
+++ b/internal/unarchive/extract/extract_test.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"io/fs"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/babybabycloud/terraform-provider-unarchive/internal/unarchive/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,11 +42,11 @@ func TestExtract(t *testing.T) {
 		Type:   TAR,
 		IsFlat: true,
 		Outdir: "/tmp",
-		Include: func(name string) bool {
-			return strings.Contains(name, "include")
-		},
-		Exclude: func(name string) bool {
-			return strings.Contains(name, "exclude")
+		Filters: []ConfigFilter{
+			{
+				Includes: common.Patterns{"include"},
+				Excludes: common.Patterns{"exclude"},
+			},
 		},
 	}
 

--- a/internal/unarchive/extract/handler.go
+++ b/internal/unarchive/extract/handler.go
@@ -34,7 +34,6 @@ func getHandler(hType string) handler {
 	case TARGZ:
 		return &targzHandler{}
 	default:
-		// Add unknown handler
-		return nil
+		return &unknownHandler{}
 	}
 }

--- a/internal/unarchive/extract/handler_test.go
+++ b/internal/unarchive/extract/handler_test.go
@@ -1,0 +1,39 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetZipHandler(t *testing.T) {
+	handlerType := ".zip"
+	handler := getHandler(handlerType)
+
+	_, ok := handler.(*zipHandler)
+	assert.True(t, ok)
+}
+
+func TestGetTarHandler(t *testing.T) {
+	handlerType := ".tar"
+	handler := getHandler(handlerType)
+
+	_, ok := handler.(*tarHandler)
+	assert.True(t, ok)
+}
+
+func TestGetTarGzHandler(t *testing.T) {
+	handlerType := ".tar.gz"
+	handler := getHandler(handlerType)
+
+	_, ok := handler.(*targzHandler)
+	assert.True(t, ok)
+}
+
+func TestGetUnknownHandler(t *testing.T) {
+	handlerType := "any"
+	handler := getHandler(handlerType)
+
+	_, ok := handler.(*unknownHandler)
+	assert.True(t, ok)
+}

--- a/internal/unarchive/extract/info_test.go
+++ b/internal/unarchive/extract/info_test.go
@@ -1,0 +1,22 @@
+package extract
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFailToOpenFile(t *testing.T) {
+	name := "any.txt"
+	err := errors.New("This is a fake error")
+
+	info := newFailToOpenFile(name, err)
+	expected := ExtractInfo{
+		Msg: fmt.Sprintf("Failed to open zip file %s", name),
+		Err: err,
+	}
+
+	assert.EqualValues(t, expected, info)
+}

--- a/internal/unarchive/extract/unknown_handler.go
+++ b/internal/unarchive/extract/unknown_handler.go
@@ -1,0 +1,15 @@
+package extract
+
+type unknownHandler struct{}
+
+func (u unknownHandler) open(name string) error {
+	panic("Unsupport type of handler")
+}
+
+func (u unknownHandler) generate(*Config, testAndCopy) []string {
+	panic("Unsupport type of handler")
+}
+
+func (u unknownHandler) close() {
+	panic("Unsupport type of handler")
+}

--- a/internal/unarchive/file_data_source.go
+++ b/internal/unarchive/file_data_source.go
@@ -42,15 +42,21 @@ func (d *unarchiveDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Optional:    true,
 				Description: `output specifies where the extracted files to be put.`,
 			},
-			"includes": schema.ListAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: `inclules specifies which file should be extracted. It uses regular express to find the files. It is a list`,
-			},
-			"excludes": schema.ListAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: `inclules specifies which file should not be extracted. It uses regular express to find the files. It is a list`,
+			"filter": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"includes": schema.ListAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+							Description: `inclules specifies which file should be extracted. It uses regular express to find the files. It is a list`,
+						},
+						"excludes": schema.ListAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+							Description: `inclules specifies which file should not be extracted. It uses regular express to find the files. It is a list`,
+						},
+					},
+				},
 			},
 			"flat": schema.BoolAttribute{
 				Optional:    true,
@@ -84,15 +90,9 @@ func (d *unarchiveDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	conf := &extract.Config{
-		Ctx:     ctx,
-		Name:    model.FileName.ValueString(),
-		Include: model.IncludePatterns(),
-		Exclude: model.ExcludePatterns(),
-		Outdir:  model.DecideOutputDir(),
-		IsFlat:  model.IsFlat(),
-		Type:    model.Type.ValueString(),
-	}
+	conf := extract.FromUnarchiveDataSourceModel(model)
+	conf.Ctx = ctx
+
 	info := extract.Extract(conf)
 
 	if info.Err != nil {

--- a/internal/unarchive/file_data_source.go
+++ b/internal/unarchive/file_data_source.go
@@ -42,7 +42,8 @@ func (d *unarchiveDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Optional:    true,
 				Description: `output specifies where the extracted files to be put.`,
 			},
-			"filter": schema.ListNestedAttribute{
+			"filters": schema.ListNestedAttribute{
+				Description: `filters specifies what to be included and excluded`,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"includes": schema.ListAttribute{
@@ -57,6 +58,7 @@ func (d *unarchiveDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						},
 					},
 				},
+				Optional: true,
 			},
 			"flat": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/unarchive/model/unarchive_data_source_model.go
+++ b/internal/unarchive/model/unarchive_data_source_model.go
@@ -3,21 +3,24 @@ package model
 import (
 	"os"
 
-	"github.com/babybabycloud/terraform-provider-unarchive/internal/unarchive/common"
-	"github.com/babybabycloud/terraform-provider-unarchive/internal/unarchive/extract"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// FilterModel contains the expressions what include and exclude
+type FilterModel struct {
+	Includes types.List `tfsdk:"includes"`
+	Excludes types.List `tfsdk:"excludes"`
+}
+
 // UnarchiveDataSourceModel is unarchive data source model
 type UnarchiveDataSourceModel struct {
-	FileName  types.String `tfsdk:"file_name"`
-	Output    types.String `tfsdk:"output"`
-	Includes  types.List   `tfsdk:"includes"`
-	Excludes  types.List   `tfsdk:"excludes"`
-	Flat      types.Bool   `tfsdk:"flat"`
-	Type      types.String `tfsdk:"type"`
-	FileNames types.List   `tfsdk:"file_names"`
+	FileName  types.String  `tfsdk:"file_name"`
+	Output    types.String  `tfsdk:"output"`
+	Filters   []FilterModel `tfsdk:"filters"`
+	Flat      types.Bool    `tfsdk:"flat"`
+	Type      types.String  `tfsdk:"type"`
+	FileNames types.List    `tfsdk:"file_names"`
 }
 
 // DecideOutputDir gets the final output directory
@@ -31,32 +34,6 @@ func (c UnarchiveDataSourceModel) DecideOutputDir() string {
 		outputDir = c.Output.ValueString()
 	}
 	return outputDir
-}
-
-// IncludePatterns return a function helps to filter which file is included
-func (c UnarchiveDataSourceModel) IncludePatterns() extract.TestFunc {
-	if !c.Includes.IsNull() {
-		patterns := common.ToPatterns(c.Includes)
-		return func(name string) bool {
-			return patterns.DoesNameMatch(name)
-		}
-	}
-	return func(_ string) bool {
-		return true
-	}
-}
-
-// ExcludePatterns return a function helps to filter which file is excluded
-func (c UnarchiveDataSourceModel) ExcludePatterns() extract.TestFunc {
-	if !c.Excludes.IsNull() {
-		patterns := common.ToPatterns(c.Excludes)
-		return func(name string) bool {
-			return patterns.DoesNameMatch(name)
-		}
-	}
-	return func(_ string) bool {
-		return false
-	}
 }
 
 // IsFlat is if the output file should be flatted


### PR DESCRIPTION
Update the data source attribute "includes" and "excludes". Wrap them using "filters" to support multiple pairs.
Update the document reference in the README.
